### PR TITLE
ツイートの検索キーワードなどをLambda間で共有するための改修

### DIFF
--- a/app/generate_message.py
+++ b/app/generate_message.py
@@ -1,38 +1,14 @@
-import boto3
-from boto3.dynamodb.conditions import Key
-from check_datetime_in_range import *
-from generate_bd_hashtag import *
+from read_tweets_features import *
+from get_keywords import *
 
 
-def generate_message(mode):
-    table = boto3.resource('dynamodb').Table('ll-now-search-keyword')
+def generate_message(bucket):
+    tweets_features = read_tweets_features(bucket)
 
     # 検索キーワードを取得
-    # default_keywordsを取得
-    res = table.query(
-        KeyConditionExpression=Key('type').eq('default')
-    )
-    default_keywords = [d['keyword'] for d in res['Items']]
-
-    # option_keywordsを取得
-    res = table.query(
-        KeyConditionExpression=Key('type').eq('option')
-    )
-    option_keywords = []
-    option_list = res['Items']
-    for option in option_list:
-        kw = option['keyword']
-        since_str = option['since']
-        until_str = option['until']
-        if check_datetime_in_range(since_str, until_str):
-            option_keywords.append(kw)
-
-    keywords = default_keywords + option_keywords
+    keywords = get_keywords(tweets_features)
     kw_str = ' '.join(keywords)
 
-    # 生誕祭ハッシュタグを取得
-    bd_hashtag = generate_bd_hashtag(mode)
-
-    message = '現在の {} の様子です。\n\n{} #LLNow'.format(kw_str, bd_hashtag)
+    message = '現在の {} の様子です。\n\n#LLNow'.format(kw_str)
 
     return message

--- a/app/get_keywords.py
+++ b/app/get_keywords.py
@@ -1,0 +1,5 @@
+def get_keywords(tweets_features):
+    query = tweets_features['search_metadata']['query']
+    keywords = query.split(' -filter')[0].split(' OR ')
+
+    return keywords

--- a/app/main.py
+++ b/app/main.py
@@ -10,4 +10,4 @@ def main(event, context):
 
     set_post_image(bucket, key)
     twitter = set_twitter(mode)
-    post_tweet(twitter, mode)
+    post_tweet(twitter, bucket)

--- a/app/post_tweet.py
+++ b/app/post_tweet.py
@@ -2,7 +2,7 @@ import json
 from generate_message import *
 
 
-def post_tweet(twitter, mode):
+def post_tweet(twitter, bucket):
     url_media = 'https://upload.twitter.com/1.1/media/upload.json'
     url_post = 'https://api.twitter.com/1.1/statuses/update.json'
 
@@ -19,7 +19,7 @@ def post_tweet(twitter, mode):
     media_id = json.loads(res_media.text)['media_id']
 
     # 投稿文を生成
-    message = generate_message(mode)
+    message = generate_message(bucket)
 
     # アップロードした画像を添付したツイートを投稿
     params = {'status': message, 'media_ids': [media_id]}

--- a/app/read_tweets_features.py
+++ b/app/read_tweets_features.py
@@ -1,0 +1,14 @@
+import boto3
+import json
+
+
+def read_tweets_features(bucket):
+    key = 'tmp/tweets_features'
+    s3 = boto3.resource('s3')
+    bucket = s3.Bucket(bucket)
+    obj = bucket.Object(key)
+    response = obj.get()
+    body = response['Body'].read()
+    tweets_features = json.loads(body.decode('utf-8'))
+
+    return tweets_features


### PR DESCRIPTION
* 生誕祭ハッシュタグをキーワードと別で取得しない

* ツイート文に書くキーワードを実行時刻をもとにDynamoDbから取得するのではなくtweets_features>search_metadata>queryから取得する